### PR TITLE
Adding the option to set the working dir of the build process

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
   gcr_project_id:
     description: 'google project Id'
     required: true
+  working_dir:
+    description: 'the directory to look the docker file in'
+    required: false
+    default: '.'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,10 @@
 
 IMAGE_NAME="$INPUT_GCR_HOST/$INPUT_GCR_PROJECT_ID/$INPUT_IMAGE_NAME:$INPUT_IMAGE_TAG"
 
+
 echo -n $GCLOUD_SERVICE_KEY | docker login -u _json_key --password-stdin https://$INPUT_GCR_HOST/
-docker build -t $IMAGE_NAME  .
+
+cd $INPUT_WORKING_DIR
+
+docker build -t $IMAGE_NAME .
 docker push $IMAGE_NAME


### PR DESCRIPTION
Currently if we have a repo with multiple docker images we need a way to set the working-directory in order to build them.
Github does have a `working-directory` directive but it cannot be used along with the `use` keyword.